### PR TITLE
design: agrega variables.css con guía de estilos de Balbi Home

### DIFF
--- a/frontend/frontend-vanilla/css/variables.css
+++ b/frontend/frontend-vanilla/css/variables.css
@@ -1,0 +1,61 @@
+/* ========================================
+   VARIABLES GLOBALES — BALBI HOME
+   design/style-guide
+   ======================================== */
+
+:root {
+  /* === COLORES PRINCIPALES === */
+  --color-primary: #C0392B;        /* Rojo ladrillo — color principal de marca */
+  --color-primary-dark: #962d22;   /* Rojo oscuro — hover */
+  --color-secondary: #3D3D3D;      /* Gris oscuro — texto principal */
+  --color-accent: #F2EAD8;         /* Beige crema — fondos destacados */
+
+  /* === FONDOS === */
+  --color-bg: #FFFFFF;             /* Fondo general */
+  --color-bg-soft: #FAF7F4;        /* Fondo suave — secciones alternas */
+  --color-bg-dark: #2C2C2C;        /* Fondo oscuro — footer */
+
+  /* === TEXTOS === */
+  --color-text: #3D3D3D;           /* Texto principal */
+  --color-text-soft: #6B6B6B;      /* Texto secundario */
+  --color-text-light: #FFFFFF;     /* Texto sobre fondos oscuros */
+
+  /* === BORDES === */
+  --color-border: #E0D9CF;         /* Bordes suaves */
+
+  /* === TIPOGRAFÍAS === */
+  --font-primary: 'Montserrat', sans-serif;    /* Títulos — similar al logo */
+  --font-secondary: 'Lato', sans-serif;        /* Cuerpo de texto */
+
+  /* === TAMAÑOS DE FUENTE === */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+
+  /* === ESPACIADO === */
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+  --spacing-2xl: 3rem;
+
+  /* === BORDES REDONDEADOS === */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --radius-full: 9999px;
+
+  /* === SOMBRAS === */
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.08);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.10);
+  --shadow-lg: 0 8px 24px rgba(0,0,0,0.12);
+
+  /* === TRANSICIONES === */
+  --transition: all 0.3s ease;
+}


### PR DESCRIPTION
## Qué se hizo
Se creó el archivo variables.css con la paleta de colores y tipografías basadas en la identidad visual real de Balbi Home.

## Por qué
Closes #8

## Vinculación obligatoria
- Issue / Tarjeta en GitHub Projects: #8
- Sprint: Sprint 1
- Rama: design/style-guide

## Cómo probar
1. Abrir el archivo frontend/frontend-vanilla/css/variables.css
2. Verificar que contiene los colores y tipografías de Balbi Home

## Uso de IA
Se usó IA para generar la paleta de colores en base al logo real de Balbi Home. Se validaron los colores manualmente comparando con el logo oficial.

## Notas para el reviewer
Colores extraídos del logo oficial de Balbi Home. Este archivo será importado en todas las páginas HTML del proyecto.

## Checklist (Definition of Done)
- [x] Cumple el enunciado del sprint indicado
- [ ] Hay evidencia de prueba (tests o pasos manuales)
- [x] No se subieron secretos (`.env`, credenciales, claves)
- [x] Los commits siguen Conventional Commits (`type(scope): ...`)
- [x] El PR referencia el issue con `Closes #8`